### PR TITLE
Update README with latest vscode params

### DIFF
--- a/bash/README.md
+++ b/bash/README.md
@@ -81,7 +81,7 @@ see https://github.com/rogalmic/vscode-bash-debug/issues/67
 			"name": "Bash-Debug (hardcoded script name)",
 			"type": "bashdb",
 			"request": "launch",
-			"scriptPath": "${workspaceRoot}/bubbleSort.sh",
+			"program": "${workspaceRoot}/bubbleSort.sh",
 			"commandLineArguments": "4 3 2 1"
 		}
 	]


### PR DESCRIPTION
According to my latest version of Visual Studio Code (1.32.3), `scriptPath` has been renamed to `program`